### PR TITLE
fix: update TinyDB parser to use event_attendees key and parse JSON keys

### DIFF
--- a/pkg/migration/importer.go
+++ b/pkg/migration/importer.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/PodioSpaz/event-tracker-go/internal/repository"
 	"github.com/rs/zerolog/log"
@@ -106,6 +107,16 @@ func (i *Importer) importPeople(ctx context.Context, doc *TinyDBDocument, stats 
 	personIDMap := make(map[int]int64)
 
 	for id, tdbPerson := range doc.People {
+		// Parse the TinyDB document ID from JSON key
+		docID, err := strconv.Atoi(id)
+		if err != nil {
+			stats.PeopleFailed++
+			errMsg := fmt.Sprintf("Failed to parse person ID %s: %v", id, err)
+			stats.Errors = append(stats.Errors, errMsg)
+			log.Warn().Str("id", id).Err(err).Msg("Failed to parse person ID")
+			continue
+		}
+
 		// Map to domain model
 		person, err := i.mapper.MapPerson(&tdbPerson)
 		if err != nil {
@@ -139,7 +150,7 @@ func (i *Importer) importPeople(ctx context.Context, doc *TinyDBDocument, stats 
 				// Try to find existing person
 				existing, err := i.personRepo.FindByEmail(ctx, person.Email)
 				if err == nil && existing != nil {
-					personIDMap[tdbPerson.DocID] = existing.ID
+					personIDMap[docID] = existing.ID
 					stats.PeopleImported++
 					log.Info().Str("email", person.Email).Msg("Person already exists, using existing ID")
 					continue
@@ -157,7 +168,7 @@ func (i *Importer) importPeople(ctx context.Context, doc *TinyDBDocument, stats 
 		}
 
 		// Store ID mapping
-		personIDMap[tdbPerson.DocID] = person.ID
+		personIDMap[docID] = person.ID
 		stats.PeopleImported++
 
 		log.Debug().
@@ -177,6 +188,16 @@ func (i *Importer) importActivities(ctx context.Context, doc *TinyDBDocument, st
 	activityIDMap := make(map[int]int64)
 
 	for id, tdbActivity := range doc.Activities {
+		// Parse the TinyDB document ID from JSON key
+		docID, err := strconv.Atoi(id)
+		if err != nil {
+			stats.ActivitiesFailed++
+			errMsg := fmt.Sprintf("Failed to parse activity ID %s: %v", id, err)
+			stats.Errors = append(stats.Errors, errMsg)
+			log.Warn().Str("id", id).Err(err).Msg("Failed to parse activity ID")
+			continue
+		}
+
 		// Map to domain model
 		activity, err := i.mapper.MapActivity(&tdbActivity)
 		if err != nil {
@@ -206,7 +227,7 @@ func (i *Importer) importActivities(ctx context.Context, doc *TinyDBDocument, st
 		}
 
 		// Store ID mapping
-		activityIDMap[tdbActivity.DocID] = activity.ID
+		activityIDMap[docID] = activity.ID
 		stats.ActivitiesImported++
 
 		log.Debug().

--- a/pkg/migration/tinydb.go
+++ b/pkg/migration/tinydb.go
@@ -11,7 +11,7 @@ import (
 type TinyDBDocument struct {
 	Activities map[string]TinyDBActivity `json:"activities"`
 	People     map[string]TinyDBPerson   `json:"people"`
-	Attendees  map[string]TinyDBAttendee `json:"attendees"`
+	Attendees  map[string]TinyDBAttendee `json:"event_attendees"`
 }
 
 // TinyDBActivity represents an activity in TinyDB format

--- a/pkg/migration/tinydb_test.go
+++ b/pkg/migration/tinydb_test.go
@@ -41,7 +41,7 @@ func TestTinyDBParser_ParseData(t *testing.T) {
 					"updated_at": "2024-01-01T00:00:00"
 				}
 			},
-			"attendees": {
+			"event_attendees": {
 				"1": {
 					"_id": 1,
 					"activity_id": 1,
@@ -67,7 +67,7 @@ func TestTinyDBParser_ParseData(t *testing.T) {
 		jsonData := []byte(`{
 			"activities": {},
 			"people": {},
-			"attendees": {}
+			"event_attendees": {}
 		}`)
 
 		doc, err := parser.ParseData(jsonData)

--- a/testdata/sample_tinydb.json
+++ b/testdata/sample_tinydb.json
@@ -66,7 +66,7 @@
       "updated_at": "2024-01-07T12:00:00"
     }
   },
-  "attendees": {
+  "event_attendees": {
     "1": {
       "_id": 1,
       "activity_id": 1,


### PR DESCRIPTION
## Summary

Fixes two related bugs in the TinyDB migration that prevented attendee records from being imported:

- **Bug 1:** Parser used `json:"attendees"` instead of `json:"event_attendees"`, causing all attendee records to be silently ignored during import
- **Bug 2:** Importer used the `_id` field for ID mapping instead of parsing JSON keys. Since the Python Event Tracker doesn't always populate the `_id` field (it's null in production data), all ID mappings defaulted to 0, breaking foreign key lookups

## Changes

- Updated `TinyDBDocument` struct tag from `"attendees"` to `"event_attendees"` to match Python Event Tracker exports and documentation
- Modified importer to parse JSON keys (e.g., `"4"`, `"5"`) as document IDs instead of relying on the `_id` field
- Updated test data files and unit tests to use `"event_attendees"` key
- Added `strconv` import for parsing string IDs to integers

## Test Plan

- [x] All migration unit tests pass (8 tests)
- [x] Sample data import: Successfully imports 3 attendees
- [x] Real Python Event Tracker data: Successfully imports all 20 attendees (previously 0)
- [x] Database stats confirm correct record counts
- [x] No regression in other import functionality

## Results

**Before:**
```
Attendees: Imported: 0, Failed: 20
```

**After:**
```
Attendees: Imported: 20, Failed: 0
Database Statistics:
  Activities:    2
  People:        55
  Attendees:     20 ✓
```

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)