### PR TITLE
fix: replace direct label assignment with SetText() in Activities table

### DIFF
--- a/internal/ui/activities.go
+++ b/internal/ui/activities.go
@@ -97,20 +97,23 @@ func (v *ActivitiesView) createActivitiesTable(activities []*domain.Activity) fy
 			// Header row styling
 			if id.Row == 0 {
 				label.TextStyle = fyne.TextStyle{Bold: true}
-				label.Text = data[id.Row][id.Col]
+				label.SetText(data[id.Row][id.Col])
 				return
 			}
 
 			// Action column
 			if id.Col == 6 {
 				// We'll show just text for now, buttons in tables are complex in Fyne
-				label.Text = "→"
+				label.SetText("→")
 				return
 			}
 
-			label.Text = data[id.Row][id.Col]
+			label.SetText(data[id.Row][id.Col])
 		},
 	)
+
+	// Refresh table to ensure initial render with data
+	table.Refresh()
 
 	// Set column widths
 	table.SetColumnWidth(0, 200) // Name


### PR DESCRIPTION
## Summary

Fixes the Activities page displaying "Template" placeholders instead of actual activity data.

**Root Cause:** The Fyne table widget update callbacks were using direct property assignment (`label.Text = value`) instead of the proper setter method (`label.SetText(value)`), which prevented the UI from properly updating.

**Changes:**
- Replaced all `label.Text =` assignments with `label.SetText()` calls in the table update callback
- Added `table.Refresh()` call after table creation to force initial render with data
- Aligned implementation with working patterns already used in `people.go`

## Test Plan

- [x] Build application successfully
- [x] Run the application
- [x] Navigate to Activities page
- [x] Verify activities table displays actual data (2026 Women's Retreat, 2025 Fall Kickoff)
- [x] Verify all columns render correctly: Name, Date, Location, Type, Status, Capacity, Actions
- [x] Verify no "Template" placeholders are visible
- [x] Verify table rows are clickable and navigate to activity details

🤖 Generated with [Claude Code](https://claude.com/claude-code)